### PR TITLE
Problème encodage côté jeedom

### DIFF
--- a/JeedomSBcontrol/Plugin.pm
+++ b/JeedomSBcontrol/Plugin.pm
@@ -17,6 +17,7 @@ package Plugins::JeedomSBcontrol::Plugin;
 # modify it under the terms of the GNU General Public License,
 # version 2.
 
+
 # required bit
 use strict;
 


### PR DESCRIPTION
Bonjour,

Il y aurait une modif à faire dans le plugin côté jeedom (comme je n’ai pas accès au git, je te le dis ici):

Problème et solution remontés sur le forum jeedom si le titre de la chanson contient des caractères accentués (et sûrement d’autres caractères spéciaux)
C’est juste un soucis d’encodage.
le fichier à modifier est le suivant : /var/www/html/plugins/squeezeboxcontrol/core/php/squeezeboxcontrolApi.php
$value = UTF8_encode(init('value'));