### PR TITLE
Change Max version

### DIFF
--- a/JeedomSBcontrol/install.xml
+++ b/JeedomSBcontrol/install.xml
@@ -17,7 +17,7 @@
         <targetApplication>
   	        <id>SqueezeCenter</id>
                 <minVersion>7.0a</minVersion>
-                <maxVersion>7+</maxVersion>
+                <maxVersion>8</maxVersion>
         </targetApplication>
 
 </extension>


### PR DESCRIPTION
Ça fonctionne aussi sur la 8.0.0 en changeant juste la version Max pour l’autoriser.

La version n’étant pas proposée automatiquement, cela ne doit gêner personne, mais comme ça tu as l’info que ça marche.